### PR TITLE
ENG-25612 Fix external-dns spec

### DIFF
--- a/kubernetes.go
+++ b/kubernetes.go
@@ -417,15 +417,22 @@ func serviceHostnameIndexFunc(obj interface{}) ([]string, error) {
 	}
 
 	hostname := service.Name + "." + service.Namespace
+	hostnames := []string{}
 	if annotation, exists := checkServiceAnnotation(hostnameAnnotationKey, service); exists {
-		hostname = annotation
+		hostnames = []string{annotation}
 	} else if annotation, exists := checkServiceAnnotation(externalDnsHostnameAnnotationKey, service); exists {
-		hostname = annotation
+		hostnames = splitHostnameAnnotation(annotation)
+	} else {
+		hostnames = []string{hostname}
 	}
 
 	log.Debugf("Adding index %s for service %s", hostname, service.Name)
 
-	return []string{hostname}, nil
+	return hostnames, nil
+}
+
+func splitHostnameAnnotation(annotation string) []string {
+	return strings.Split(strings.ReplaceAll(annotation, " ", ""), ",")
 }
 
 func checkServiceAnnotation(annotation string, service *core.Service) (string, bool) {


### PR DESCRIPTION
### Issue
External DNS allows for comma separated domains in its spec.

https://github.com/kubernetes-sigs/external-dns/blob/master/docs/annotations/annotations.md#external-dnsalphakubernetesiohostname

This however does not.

### Changes
* Allows for comma separated domains from external-dns